### PR TITLE
Update notification options

### DIFF
--- a/plugins/modules/notification.py
+++ b/plugins/modules/notification.py
@@ -30,7 +30,7 @@ options:
       - The name of the notification.
       - Only required if no I(id) specified.
     type: str
-  default:
+  isDefault:
     description: True if the notification is the default.
     type: bool
   state:
@@ -50,7 +50,7 @@ EXAMPLES = r'''
     api_password: secret123
     name: Notification 1
     type: telegram
-    default: false
+    isDefault: false
     telegramBotToken: 1111
     telegramChatID: 2222
     state: present
@@ -62,7 +62,7 @@ EXAMPLES = r'''
     api_password: secret123
     name: Notification 1
     type: telegram
-    default: false
+    isDefault: false
     telegramBotToken: 6666
     telegramChatID: 7777
     state: present
@@ -147,7 +147,7 @@ def main():
     module_args = dict(
         id=dict(type="int"),
         name=dict(type="str"),
-        default=dict(type="bool"),
+        isDefault=dict(type="bool", aliases=["default"]),
         state=dict(type="str", default="present", choices=["present", "absent"])
     )
 

--- a/plugins/modules/notification.py
+++ b/plugins/modules/notification.py
@@ -33,6 +33,9 @@ options:
   isDefault:
     description: True if the notification is the default.
     type: bool
+  applyExisting:
+    description: True if the notification is applied to all existing monitors.
+    type: bool
   state:
     description:
       - Set to C(present) to create/update a notification.
@@ -51,6 +54,7 @@ EXAMPLES = r'''
     name: Notification 1
     type: telegram
     isDefault: false
+    applyExisting: false
     telegramBotToken: 1111
     telegramChatID: 2222
     state: present
@@ -63,6 +67,7 @@ EXAMPLES = r'''
     name: Notification 1
     type: telegram
     isDefault: false
+    applyExisting: false
     telegramBotToken: 6666
     telegramChatID: 7777
     state: present
@@ -148,6 +153,7 @@ def main():
         id=dict(type="int"),
         name=dict(type="str"),
         isDefault=dict(type="bool", aliases=["default"]),
+        applyExisting=dict(type="bool"),
         state=dict(type="str", default="present", choices=["present", "absent"])
     )
 

--- a/plugins/modules/notification_info.py
+++ b/plugins/modules/notification_info.py
@@ -66,7 +66,7 @@ notifications:
       description: 
       returned: always
       sample: 1
-    default:
+    isDefault:
       description: 
       returned: always
       type: bool

--- a/plugins/modules/notification_info.py
+++ b/plugins/modules/notification_info.py
@@ -67,7 +67,7 @@ notifications:
       returned: always
       sample: 1
     isDefault:
-      description: 
+      description: True if the notification is the default.
       returned: always
       type: bool
       sample: False

--- a/plugins/modules/notification_info.py
+++ b/plugins/modules/notification_info.py
@@ -71,6 +71,10 @@ notifications:
       returned: always
       type: bool
       sample: False
+    applyExisting:
+      description: True if the notification is applied to all existing monitors.
+      returned: always
+      type: bool
     type:
       description: 
       returned: always


### PR DESCRIPTION
This PR makes two specific updates to the notification and notification_info modules. First, it migrates the `default` notification arg to `isDefault`, in order to match what the [uptime-kuma-api](https://github.com/lucasheld/uptime-kuma-api/blob/master/uptime_kuma_api/api.py#L172) is expecting, while including `default` as an alias to ensure compatibility with existing playbooks. Second, it adds the ability for playbooks to use the `applyExisting` arg, which is fully supported by [uptime-kuma-api](https://github.com/lucasheld/uptime-kuma-api/blob/master/uptime_kuma_api/api.py#L176), but not currently included in the Ansible module. Lastly, this PR updates the related documentation/examples.