### PR TITLE
fix creation of mysql monitor

### DIFF
--- a/plugins/modules/monitor.py
+++ b/plugins/modules/monitor.py
@@ -287,6 +287,8 @@ def run(api, params, result):
             params["databaseConnectionString"] = "Server=<hostname>,<port>;Database=<your database>;User Id=<your user id>;Password=<your password>;Encrypt=<true/false>;TrustServerCertificate=<Yes/No>;Connection Timeout=<int>"
         elif params["type"] == MonitorType.POSTGRES:
             params["databaseConnectionString"] = "postgres://username:password@host:port/database"
+        elif params["type"] == MonitorType.MYSQL:
+            params["databaseConnectionString"] = "mysql://username:password@host:port/database"
 
     if not params["port"]:
         if type == MonitorType.DNS:
@@ -351,7 +353,7 @@ def main():
     module_args = dict(
         id=dict(type="int"),
         name=dict(type="str"),
-        type=dict(type="str", choices=["http", "port", "ping", "keyword", "dns", "docker", "push", "steam", "mqtt", "sqlserver", "postgres", "radius"]),
+        type=dict(type="str", choices=["http", "port", "ping", "keyword", "dns", "docker", "push", "steam", "mqtt", "sqlserver", "postgres", "mysql", "radius"]),
         interval=dict(type="int"),
         retryInterval=dict(type="int"),
         resendInterval=dict(type="int"),
@@ -408,7 +410,7 @@ def main():
         mqttTopic=dict(type="str"),
         mqttSuccessMessage=dict(type="str"),
 
-        # SQLSERVER, POSTGRES
+        # SQLSERVER, POSTGRES, MYSQL
         databaseConnectionString=dict(type="str"),
         databaseQuery=dict(type="str"),
 


### PR DESCRIPTION
Hello folks, 

I got the following error if I want to create a mysql monitor:

```bash
TASK [uptime-kuma : Manage database monitor] *************************************************************************************************************************************************************
failed: [example-host] (item={'name': 'Availability - MariaDB Database some_database_name', 'type': 'mysql', 'databaseConnectionString': 'mysql://user:xxxxxxxxxxxx@192.168.0.100:3306/some_database_name', 'databaseQuery': 'select count(*) from oc_users;', 'interval': 300, 'retryinterval': 300, 'notification_names': ['My Home Alerts']}) => changed=false 
  ansible_loop_var: item
  item:
    databaseConnectionString: mysql://user:xxxxxxxxxxxx@192.168.0.100:3306/some_database_name
    databaseQuery: select count(*) from oc_users;
    interval: 300
    name: Availability - MariaDB Database some_database_name
    notification_names:
    - My Home Alerts
    retryinterval: 300
    type: mysql
  msg: 'value of type must be one of: http, port, ping, keyword, dns, docker, push, steam, mqtt, sqlserver, postgres, radius, got: mysql'
```

I use the lastest version of `ansible-uptime-kuma`.

Please review and merge the following changes. 