### PR TITLE
Add minimal support for diff to monitor plugin

### DIFF
--- a/plugins/modules/monitor.py
+++ b/plugins/modules/monitor.py
@@ -6,6 +6,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import yaml
+import enum
+
 __metaclass__ = type
 
 
@@ -311,6 +314,40 @@ except ImportError:
     HAS_UPTIME_KUMA_API = False
 
 
+def monitor_diff(before_monitor, new_options):
+    # Calculate diff
+    before_options = {}
+    after_options = {}
+    for option_key, option_value in new_options.items():
+        # Not returning "id" field in diff view
+        if option_key == "id":
+            continue
+        if before_monitor:
+            before_option_value = before_monitor[option_key]
+            # Have to translate enums into their values
+            # so they match input
+            if isinstance(before_option_value, enum.Enum):
+                before_option_value = before_option_value.value
+            before_options[option_key] = before_option_value
+
+        if isinstance(option_value, enum.Enum):
+            option_value = option_value.value
+        after_options[option_key] = option_value
+
+    # If it's a new object we need to make it an empty string
+    # Otherwise yaml will dump the string "{}"
+    if before_options:
+        before_str = yaml.safe_dump(before_options)
+    else:
+        before_str = ''
+
+    diff = {
+        'before': before_str,
+        'after': yaml.safe_dump(after_options),
+    }
+    return diff
+
+
 def run(api, params, result):
     if not params["accepted_statuscodes"]:
         params["accepted_statuscodes"] = ["200-299"]
@@ -373,11 +410,13 @@ def run(api, params, result):
         if not monitor:
             api.add_monitor(**options)
             result["changed"] = True
+            result["diff"] = monitor_diff({}, options)
         else:
             changed_keys = object_changed(monitor, options)
             if changed_keys:
                 api.edit_monitor(monitor["id"], **options)
                 result["changed"] = True
+                result["diff"] = monitor_diff(monitor, options)
     elif state == "absent":
         if monitor:
             api.delete_monitor(monitor["id"])

--- a/tests/unit/plugins/module_utils/test_monitor.py
+++ b/tests/unit/plugins/module_utils/test_monitor.py
@@ -96,6 +96,24 @@ class TestMonitor(ModuleTestCase):
 
         result = self.run_module(module, self.params)
         self.assertTrue(result["changed"])
+        self.assertEqual(result["diff"]["before"], '')
+        expected_diff_after = f"""
+accepted_statuscodes:
+- 200-299
+interval: 60
+maxretries: 0
+name: monitor 1
+notificationIDList:
+- {notification_id_1}
+- {notification_id_2}
+resendInterval: 0
+retryInterval: 60
+type: http
+upsideDown: false
+url: http://127.0.0.1
+        """
+        self.assertEqual(result["diff"]["after"].strip(), expected_diff_after.strip())
+
         monitor = get_monitor_by_name(self.api, self.params["name"])
         self.assertEqual(monitor["type"], self.params["type"])
         self.assertEqual(monitor["interval"], self.params["interval"])
@@ -117,6 +135,41 @@ class TestMonitor(ModuleTestCase):
         })
         result = self.run_module(module, self.params)
         self.assertTrue(result["changed"])
+        expected_diff_before = f"""
+accepted_statuscodes:
+- 200-299
+hostname: null
+interval: 60
+maxretries: 0
+name: monitor 1
+notificationIDList:
+- {notification_id_1}
+- {notification_id_2}
+resendInterval: 0
+retryInterval: 60
+type: http
+upsideDown: false
+url: http://127.0.0.1
+        """
+        self.assertEqual(result["diff"]["before"].strip(), expected_diff_before.strip())
+        expected_diff_after = f"""
+accepted_statuscodes:
+- 200-299
+hostname: 127.0.0.10
+interval: 60
+maxretries: 0
+name: monitor 1
+notificationIDList:
+- {notification_id_1}
+- {notification_id_2}
+resendInterval: 0
+retryInterval: 60
+type: ping
+upsideDown: false
+url: http://127.0.0.1
+        """
+        self.assertEqual(result["diff"]["after"].strip(), expected_diff_after.strip())
+
         monitor = self.api.get_monitor(monitor_id)
         self.assertEqual(monitor["type"], self.params["type"])
         self.assertEqual(monitor["hostname"], self.params["hostname"])


### PR DESCRIPTION
This change adds very minimal diff support for just the monitor plugin. It only does a diff based on the arguments passed in by the user and only supports only the "present" state.

To support a "full" diff, it would be necessary to make an additional network call to get the new monitor configuration from the instance. To avoid this, the code just diffs the changes passed in.

Please let me know if there's any changes you'd like me to make. I tested this on a local copy using the following playbook:

```yaml
- hosts: 127.0.0.1
  tasks:
    - name: Setup
      lucasheld.uptime_kuma.setup:
        api_url: http://127.0.0.1:3001
        api_username: admin
        api_password: secret123
    - name: Login to get a token for other roles that want to create monitors
      lucasheld.uptime_kuma.login:
        api_url: http://127.0.0.1:3001
        api_username: admin
        api_password: secret123
      register: uptime_kuma_result
    - name: Set login token
      set_fact:
        uptime_kuma_token: "{{ uptime_kuma_result.token }}" 
    - name: add monitor
      lucasheld.uptime_kuma.monitor:
        api_url: http://127.0.0.1:3001
        api_token: "{{ uptime_kuma_token }}"
        name: google
        type: http
        url: https://google.com
        state: present
    - name: update monitor
      lucasheld.uptime_kuma.monitor:
        api_url: http://127.0.0.1:3001
        api_token: "{{ uptime_kuma_token }}"
        name: google
        type: ping
        hostname: 127.0.0.10
        url: https://google.com
        state: present
    - name: remove monitor
      lucasheld.uptime_kuma.monitor:
        api_url: http://127.0.0.1:3001
        api_token: "{{ uptime_kuma_token }}"
        name: google
        type: http
        url: https://google.com
        state: absent
```

Putting this file at the repo root and running the following command should execute the playbook: `COLLECTIONS_PATHS="./:/usr/share/ansible/collections"  ansible-playbook kuma-test-playbook.yml --diff` (you may have to adjust the `COLLECTIONS_PATH` setting to suit your environment.

This should produce the following output (truncated to relevant parts):
```
TASK [add monitor]
--- before
+++ after
@@ -0,0 +1,5 @@
+accepted_statuscodes:
+- 200-299
+name: google
+type: http
+url: https://google.com

changed: [127.0.0.1]

TASK [update monitor]
--- before
+++ after
@@ -1,6 +1,6 @@
 accepted_statuscodes:
 - 200-299
-hostname: null
+hostname: 127.0.0.10
 name: google
-type: http
+type: ping
 url: https://google.com

changed: [127.0.0.1]

TASK [remove monitor]
changed: [127.0.0.1]
```