### PR TITLE
Fix failing status_page test

### DIFF
--- a/plugins/modules/status_page.py
+++ b/plugins/modules/status_page.py
@@ -190,7 +190,7 @@ def run(api, params, result):
             else:
                 monitor_name = monitor.pop("name")
                 monitor["id"] = get_monitor_by_name(api, monitor_name)["id"]
-            if monitor["sendUrl"] is None:
+            if "sendUrl" in monitor and monitor["sendUrl"] is None:
                 monitor.pop("sendUrl")
 
     try:


### PR DESCRIPTION
The test does not supply a `sendUrl` field which makes the test fail. By checking whether the key exists the test passes again.

While working on #34 I noticed that the test was failing so I think this should fix the problem. It was only introduced in #32 two weeks ago and probably slipped through.

Note that tests still fail currently due to https://github.com/lucasheld/uptime-kuma-api/pull/48 not being merged yet, but if you want the test to succeed, just run it against the `louislam/uptime-kuma:1.22.1` image, that worked for me.

For some reason `TestStatusPageInfo.test_all_status_pages` also fails for me (but it does on `master`, too). I haven't investigated that failure yet.