### PR TITLE
Feature: Add showCertificateExpiry property to status_page module

### DIFF
--- a/plugins/modules/status_page.py
+++ b/plugins/modules/status_page.py
@@ -37,6 +37,9 @@ options:
   published:
     description: True if the status page is published.
     type: bool
+  showCertificateExpiry:
+    description: Show Certificate Expiry.
+    type: bool
   showTags:
     description: True if the tags are shown.
     type: bool
@@ -233,6 +236,7 @@ def main():
         description=dict(type="str"),
         theme=dict(type="str", choices=["auto", "light", "dark"]),
         published=dict(type="bool"),
+        showCertificateExpiry=dict(type="bool"),
         showTags=dict(type="bool"),
         domainNameList=dict(type="list", elements="str"),
         googleAnalyticsId=dict(type="str"),

--- a/tests/unit/plugins/module_utils/test_status_page.py
+++ b/tests/unit/plugins/module_utils/test_status_page.py
@@ -15,6 +15,7 @@ class TestStatusPage(ModuleTestCase):
             "description": None,
             "theme": None,
             "published": None,
+            "showCertificateExpiry": None,
             "showTags": None,
             "domainNameList": None,
             "googleAnalyticsId": None,
@@ -38,6 +39,7 @@ class TestStatusPage(ModuleTestCase):
             "description": "description 1",
             "theme": "light",
             "published": True,
+            "showCertificateExpiry": False,
             "showTags": False,
             "domainNameList": [],
             "googleAnalyticsId": None,
@@ -66,6 +68,7 @@ class TestStatusPage(ModuleTestCase):
         self.assertEqual(status_page["description"], self.params["description"])
         self.assertEqual(status_page["theme"], self.params["theme"])
         self.assertEqual(status_page["published"], self.params["published"])
+        self.assertEqual(status_page["showCertificateExpiry"], self.params["showCertificateExpiry"])
         self.assertEqual(status_page["showTags"], self.params["showTags"])
         self.assertEqual(status_page["domainNameList"], self.params["domainNameList"])
         self.assertEqual(status_page["googleAnalyticsId"], self.params["googleAnalyticsId"])


### PR DESCRIPTION
While using your collection to configure an uptime instance and defining monitors & status page I came across the issue, that I cannot set the "showCertificateExpiry" property for a status page.
A quick look into the API reference (here: https://uptime-kuma-api.readthedocs.io/en/latest/api.html#uptime_kuma_api.UptimeKumaApi.save_status_page) revealed that the API has indeed the capability to configure this.

In this PR I have created a quick implementation for this feature and also added it to the unit test. I have not tested it myself so far, I will add a comment to this PR.

Please have look - it would really help us to get this merged.