### PR TITLE
Fix adding status page through maintenance module. The API asks for '…

### DIFF
--- a/plugins/modules/maintenance.py
+++ b/plugins/modules/maintenance.py
@@ -242,8 +242,8 @@ def run(api, params, result):
             # add id or name to status page
             for status_page in status_pages:
                 if "id" not in status_page:
-                    status_page_name = status_page.pop("name")
-                    r = get_status_page_by(api, "name", status_page_name)
+                    status_page_name = status_page.pop("title")
+                    r = get_status_page_by(api, "title", status_page_name)
                     status_page["id"] = r["id"]
 
             # add monitors to maintenance if changed


### PR DESCRIPTION
While trying to add status_page to maintenance I found out that the API waits for the title of the status page instead of its name, so I corrected the needed lines in maintenance.py module
Bear with me, as it's my first ever PR