### PR TITLE
Add json_path_operator

### DIFF
--- a/plugins/modules/monitor.py
+++ b/plugins/modules/monitor.py
@@ -263,6 +263,9 @@ options:
   jsonPath:
     description: Json Query
     type: str
+  jsonPathOperator:
+    description: Operator for comparing json query to expectedResult
+    type: str
   expectedValue:
     description: Expected Value
     type: str
@@ -540,6 +543,7 @@ def main():
         game=dict(type="str"),
         gamedigGivenPortOnly=dict(type="bool"),
         jsonPath=dict(type="str"),
+        jsonPathOperator=dict(type="str"),
         expectedValue=dict(type="str"),
         kafkaProducerBrokers=dict(type="str"),
         kafkaProducerTopic=dict(type="str"),

--- a/plugins/modules/monitor_info.py
+++ b/plugins/modules/monitor_info.py
@@ -392,6 +392,11 @@ monitors:
       returned: always
       type: bool
       sample: False
+    jsonPathOperator:
+      description: Operator for comparing json query to expectedResult
+      returned: always
+      type: str
+      sample: None
     jsonPath:
       description: Json Query
       returned: always


### PR DESCRIPTION
Newer versions of uptime kuma allow the user to set json_path_operator.
Without this beeing set json_queries do not work, as uptime kuma tries to use "null" to compare the query.
This adds the option to ansible-uptime-kuma to get it working, again.
Verification of operators should probably be done in the python api